### PR TITLE
 添加了多页文章的导航栏

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -609,65 +609,50 @@ function origami_inspiration_init()
 add_action('init', 'origami_inspiration_init');
 
 //文末文章分页显示
-  //wp_link_pages参数列表（复制粘贴大法）
- /*$args {
-  *     Optional. Array or string of default arguments.
-  *
-  *     @type string       $before           HTML or text to prepend to each link. Default is `<p> Pages:`.
-  *     @type string       $after            HTML or text to append to each link. Default is `</p>`.
-  *     @type string       $link_before      HTML or text to prepend to each link, inside the `<a>` tag.
-  *                                          Also prepended to the current item, which is not linked. Default empty.
-  *     @type string       $link_after       HTML or text to append to each Pages link inside the `<a>` tag.
-  *                                          Also appended to the current item, which is not linked. Default empty.
-  *     @type string       $aria_current     The value for the aria-current attribute. Possible values are 'page',
-  *                                          'step', 'location', 'date', 'time', 'true', 'false'. Default is 'page'.
-  *     @type string       $next_or_number   Indicates whether page numbers should be used. Valid values are number
-  *                                          and next. Default is 'number'.
-  *     @type string       $separator        Text between pagination links. Default is ' '.
-  *     @type string       $nextpagelink     Link text for the next page link, if available. Default is 'Next Page'.
-  *     @type string       $previouspagelink Link text for the previous page link, if available. Default is 'Previous Page'.
-  *     @type string       $pagelink         Format string for page numbers. The % in the parameter string will be
-  *                                          replaced with the page number, so 'Page %' generates "Page 1", "Page 2", etc.
-  *                                          Defaults to '%', just the page number.
-  *     @type int|bool     $echo             Whether to echo or not. Accepts 1|true or 0|false. Default 1|true.
-  * }
-  * @return string Formatted output in HTML.
-  */
 function origami_content_pagesNav($content)
 {
   //代码有点乱，QAQ
-  $content .= 
-  /* 上一页标签 */
-  wp_link_pages(
-    array('before' => '<div class="pagination" id="nav_articlePages"><span id="nav_page_title">分页</span>',
-    'after' => '',
-    'next_or_number' => 'next',
-    'link_before' =>'<span id="nav_previous_page">',
-    'link_after'=>'</span>',
-    'previouspagelink' => '←上一页',
-    'nextpagelink' => "",
-    'echo' => 0  
-    )).
+  /* 使用到的函数
+    _wp_link_page($page),返回文章第$page页的html超链接，类似<a href="...">,但是没有尾标签，所以要手动加上</a>
+  
+  */
+  global $page, $numpages, $multipage, $more;
+  if($multipage && ( is_single() || is_page() ) )//只有在多页的文章或页面中才会显示导航栏
+  {
+    $content .= '<ul class="pagination">';
+    /* 上一页标签 */
+
+    //<li class="page-item disabled">
+    $prev = $page - 1;
+    if($prev > 0)
+      $link = '<li class="page-item">'. _wp_link_page( $prev ) . '上一页</a>';
+    else
+      $link = '<li class="page-item disabled"><a href="#" tabindex="-1">上一页</a>';
+    $content .= $link . '</li>';
+    
     /* 文章页码标签 */
-    wp_link_pages(array(
-    'before' => '',
-    'after' => '',
-    'next_or_number' => 'number',
-    'link_before' =>'<span class="nav_page_num">第',
-    'link_after'=>'页</span>',
-    'echo' => 0
-    )).
+    
+    //var_dump($page, $numpages, $multipage, $more);//调试输出
+    for ($i = 1; $i <= $numpages; $i++) {
+      $link = $i ;
+      if ($i != $page || !$more && 1 == $page) {
+        $link = '<li class="page-item">' . _wp_link_page($i) . $link .'</a></li>';
+      } elseif ($i === $page) {
+        $link = '<li class="page-item active"><a href="#">' . $link. '</a></li>';     
+      }
+      $content .= $link;
+    }
+  
     /* 下一页标签 */
-    wp_link_pages(array(
-    'before' => '',
-    'after' => '</div>',
-    'next_or_number' => 'next',
-    'previouspagelink' => '',
-    'link_before' =>'<span id="nav_next_page">',
-    'link_after'=>'</span>',
-    'nextpagelink' => "下一页→",
-    'echo' => 0 
-    )); 
+    
+    $next = $page + 1;
+    if($next <= $numpages)
+      $link = '<li class="page-item">'. _wp_link_page( $next ) . '下一页</a>';
+    else
+      $link = '<li class="page-item disabled"><a href="#" tabindex="-1">下一页</a>';
+    $content .= $link . '</li>';
+    $content .= '</ul>';
+  }
   return $content;
 }
 add_filter('the_content', 'origami_content_pagesNav');

--- a/functions.php
+++ b/functions.php
@@ -608,6 +608,70 @@ function origami_inspiration_init()
 }
 add_action('init', 'origami_inspiration_init');
 
+//文末文章分页显示
+  //wp_link_pages参数列表（复制粘贴大法）
+ /*$args {
+  *     Optional. Array or string of default arguments.
+  *
+  *     @type string       $before           HTML or text to prepend to each link. Default is `<p> Pages:`.
+  *     @type string       $after            HTML or text to append to each link. Default is `</p>`.
+  *     @type string       $link_before      HTML or text to prepend to each link, inside the `<a>` tag.
+  *                                          Also prepended to the current item, which is not linked. Default empty.
+  *     @type string       $link_after       HTML or text to append to each Pages link inside the `<a>` tag.
+  *                                          Also appended to the current item, which is not linked. Default empty.
+  *     @type string       $aria_current     The value for the aria-current attribute. Possible values are 'page',
+  *                                          'step', 'location', 'date', 'time', 'true', 'false'. Default is 'page'.
+  *     @type string       $next_or_number   Indicates whether page numbers should be used. Valid values are number
+  *                                          and next. Default is 'number'.
+  *     @type string       $separator        Text between pagination links. Default is ' '.
+  *     @type string       $nextpagelink     Link text for the next page link, if available. Default is 'Next Page'.
+  *     @type string       $previouspagelink Link text for the previous page link, if available. Default is 'Previous Page'.
+  *     @type string       $pagelink         Format string for page numbers. The % in the parameter string will be
+  *                                          replaced with the page number, so 'Page %' generates "Page 1", "Page 2", etc.
+  *                                          Defaults to '%', just the page number.
+  *     @type int|bool     $echo             Whether to echo or not. Accepts 1|true or 0|false. Default 1|true.
+  * }
+  * @return string Formatted output in HTML.
+  */
+function origami_content_pagesNav($content)
+{
+  //代码有点乱，QAQ
+  $content .= 
+  /* 上一页标签 */
+  wp_link_pages(
+    array('before' => '<div class="pagination" id="nav_articlePages"><span id="nav_page_title">分页</span>',
+    'after' => '',
+    'next_or_number' => 'next',
+    'link_before' =>'<span id="nav_previous_page">',
+    'link_after'=>'</span>',
+    'previouspagelink' => '←上一页',
+    'nextpagelink' => "",
+    'echo' => 0  
+    )).
+    /* 文章页码标签 */
+    wp_link_pages(array(
+    'before' => '',
+    'after' => '',
+    'next_or_number' => 'number',
+    'link_before' =>'<span class="nav_page_num">第',
+    'link_after'=>'页</span>',
+    'echo' => 0
+    )).
+    /* 下一页标签 */
+    wp_link_pages(array(
+    'before' => '',
+    'after' => '</div>',
+    'next_or_number' => 'next',
+    'previouspagelink' => '',
+    'link_before' =>'<span id="nav_next_page">',
+    'link_after'=>'</span>',
+    'nextpagelink' => "下一页→",
+    'echo' => 0 
+    )); 
+  return $content;
+}
+add_filter('the_content', 'origami_content_pagesNav');
+
 // 文末版权声明
 function origami_content_copyright($content)
 {

--- a/functions.php
+++ b/functions.php
@@ -625,9 +625,13 @@ function origami_content_pagesNav($content)
     //<li class="page-item disabled">
     $prev = $page - 1;
     if($prev > 0)
-      $link = '<li class="page-item">'. _wp_link_page( $prev ) . '上一页</a>';
+    {
+        $link = '<li class="page-item">'. _wp_link_page( $prev ) . '上一页</a>';
+    }
     else
+    {
       $link = '<li class="page-item disabled"><a href="#" tabindex="-1">上一页</a>';
+    }
     $content .= $link . '</li>';
     
     /* 文章页码标签 */
@@ -644,12 +648,16 @@ function origami_content_pagesNav($content)
     }
   
     /* 下一页标签 */
-    
+
     $next = $page + 1;
     if($next <= $numpages)
+    {
       $link = '<li class="page-item">'. _wp_link_page( $next ) . '下一页</a>';
+    }
     else
+    {
       $link = '<li class="page-item disabled"><a href="#" tabindex="-1">下一页</a>';
+    }
     $content .= $link . '</li>';
     $content .= '</ul>';
   }

--- a/style.css
+++ b/style.css
@@ -1974,6 +1974,15 @@ body.menu-active .ori-footer {
 .OwO ul li {
   margin-top: 0;
 }
+/* 文末分页导航 */
+#nav_articlePages{
+	font-weight: bold;
+	text-align:center;
+}
+.nav_page_num{padding-right:5px;padding-left:5px;}
+#nav_page_title{padding:0;}
+#nav_previous_page{padding-left:5px;}
+
 
 /* 文末版权 */
 #content-copyright {

--- a/style.css
+++ b/style.css
@@ -1974,6 +1974,7 @@ body.menu-active .ori-footer {
 .OwO ul li {
   margin-top: 0;
 }
+
 /* 文末版权 */
 #content-copyright {
   color: #4d99d2;

--- a/style.css
+++ b/style.css
@@ -1974,16 +1974,6 @@ body.menu-active .ori-footer {
 .OwO ul li {
   margin-top: 0;
 }
-/* 文末分页导航 */
-#nav_articlePages{
-	font-weight: bold;
-	text-align:center;
-}
-.nav_page_num{padding-right:5px;padding-left:5px;}
-#nav_page_title{padding:0;}
-#nav_previous_page{padding-left:5px;}
-
-
 /* 文末版权 */
 #content-copyright {
   color: #4d99d2;


### PR DESCRIPTION
* 当文章过长时，文章可以使用wordpress自带的分页标签进行分页，而如果没有导航栏，wordpress默认只会显示多页文章中的第一页，因此添加分页导航栏来增加主题对分页文章的支持
* 除此之外，导航栏使用主体自带的spectre样式，更加贴近主题